### PR TITLE
Add self-signed cert to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,13 @@ FROM nginx:1.19-alpine AS server
 
 WORKDIR /usr/share/nginx/html
 COPY --from=builder /app/build .
+
+# Make a self-signed SSL certificate
+RUN mkdir /cert
+COPY ./nginx/openssl.conf .
+RUN apk add openssl
+RUN openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -config openssl.conf \
+    -keyout /cert/ssl.key -out /cert/ssl.crt
+
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx/nginx.conf /etc/nginx/nginx.conf

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    listen 443 ssl;
+    ssl_certificate /cert/ssl.crt;
+    ssl_certificate_key /cert/ssl.key;
+
+    server_name localhost;
+
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    location / {
+        root   /usr/share/nginx/html;
+        autoindex on;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,33 @@
+# The default nginx.conf extracted from the official nginx docker image
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format main  '$remote_addr - $remote_user [$time_local] "$request" '
+                     '$status $body_bytes_sent "$http_referer" '
+                     '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/nginx/openssl.conf
+++ b/nginx/openssl.conf
@@ -1,0 +1,21 @@
+[req]
+default_bits = 2048
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = US
+ST = NA
+L = NA
+O  = NA
+CN = *.nsidc.org
+
+[v3_req]
+keyUsage = critical, digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = nsidc.org
+DNS.2 = *.nsidc.org


### PR DESCRIPTION
The nsidc.org reverse proxy requires the back-end service to provide SSL (even with a self-signed cert) to serve it behind HTTPS with its authority-signed certificate. I'm not really sure why.